### PR TITLE
Fix reported arguments for macros (on SBCL)

### DIFF
--- a/symbols.lisp
+++ b/symbols.lisp
@@ -56,7 +56,9 @@
 
 (defgeneric symb-function (symb-object)
   (:method ((symb symb-object))
-    (fdefinition (symb-symbol symb))))
+    (fdefinition (symb-symbol symb)))
+  (:method ((symb symb-macro))
+    (macro-function (symb-symbol symb))))
 
 (defgeneric symb-type (symb-object)
   (:method ((symb symb-object))


### PR DESCRIPTION
SBCL reports an arguments list of (&REST ARGS) for the function object
returned by (FDEFINITION SYMBOL). This can be fixed by instead using the
result of MACRO-FUNCTION.