### PR TITLE
Always refer to default branch in source links instead of master

### DIFF
--- a/page.lisp
+++ b/page.lisp
@@ -256,13 +256,13 @@
                                 (truename (asdf:system-source-directory (system page))))
       (let ((homepage (asdf:system-homepage (system page))))
         (cond ((search "github" homepage)
-               (format NIL "~a/blob/master/~a~@[#L~a~]"
+               (format NIL "~a/blob/HEAD/~a~@[#L~a~]"
                        (github-project-root (asdf:system-homepage (system page)))
                        (enough-namestring (getf source :file)
                                           (asdf:system-source-directory (system page)))
                        (getf source :row)))
               ((search "gitlab" homepage)
-               (format NIL "~a/-/blob/master/~a~@[#L~a~]"
+               (format NIL "~a/-/blob/HEAD/~a~@[#L~a~]"
                        (gitlab-project-root (asdf:system-homepage (system page)))
                        (enough-namestring (getf source :file)
                                           (asdf:system-source-directory (system page)))


### PR DESCRIPTION
Hello! :wave: 
The latest fashion of calling main branch in Git repos is, well, `main` these days. Staple currently hardcodes the name `master`, rendering those links broken for such new-style repos. This PR fixes it, using the `HEAD` reference, which points to the default branch for both Github ([reference](https://stackoverflow.com/a/65158264/1336774)) and GitLab (I've checked).